### PR TITLE
Configurable Versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,21 +6,26 @@ license = { text = "AGPL-3.0-only" }
 license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.11"
-authors = [
-    { name = "Paul Winterstein", email = "paul.winterstein@swr.de" },
-]
+authors = [{ name = "Paul Winterstein", email = "paul.winterstein@swr.de" }]
 maintainers = [
     { name = "SWR Media-over-IP Team", email = "moip@swr.de" },
     { name = "Josia Hildebrandt", email = "manuel_josia.hildebrandt@swr.de" },
 ]
-keywords = ["videoipath", "automation", "nevion", "media-over-ip", "st2110", "orchestration"]
+keywords = [
+    "videoipath",
+    "automation",
+    "nevion",
+    "media-over-ip",
+    "st2110",
+    "orchestration",
+]
 dependencies = [
     "requests (>=2.31.0,<3.0.0)",
     "pydantic (>=2.6.4,<3.0.0)",
     "pydantic-extra-types (>=2.6.0,<3.0.0)",
     "pydantic-settings (>=2.2.1,<3.0.0)",
     "urllib3 (>=2.2.3,<3.0.0)",
-    "deepdiff (>=8.1.1,<9.0.0)"
+    "deepdiff (>=8.1.1,<9.0.0)",
 ]
 
 [project.urls]
@@ -51,6 +56,8 @@ env_files = ["tests/.env.test"]
 [virtualenvs]
 in-project = true
 
+[project.scripts]
+set-videoipath-version = "videoipath_automation_tool.scripts.generate_all:main"
 
 [tool.ruff]
 include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]

--- a/src/videoipath_automation_tool/apps/inventory/model/drivers.py
+++ b/src/videoipath_automation_tool/apps/inventory/model/drivers.py
@@ -1,11 +1,11 @@
 from abc import ABC
-from typing import Dict, Literal, Type, TypeVar, Union, Optional
+from typing import Dict, Literal, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel, Field
 
 # Notes:
 # - The name of the custom settings model follows the naming convention: CustomSettings_<driver_organization>_<driver_name>_<driver_version> => "." and "-" are replaced by "_"!
-# - src/videoipath_automation_tool/apps/inventory/model/driver_schema/2024.1.4.json is used as reference to define the custom settings model!
+# - Schema 2024.4.12.json is used as reference to define the custom settings model!
 # - The "driver_id" attribute is necessary for the discriminator, which is used to determine the correct model for the custom settings in DeviceConfiguration!
 # - The "alias" attribute is used to map the attribute to the correct key (with driver organization & name) in the JSON payload for the API!
 # - "DriverLiteral" is used to provide a list of all possible drivers in the IDEs IntelliSense!

--- a/src/videoipath_automation_tool/scripts/generate_all.py
+++ b/src/videoipath_automation_tool/scripts/generate_all.py
@@ -1,16 +1,27 @@
-from videoipath_automation_tool.scripts.generate_driver_models import DEFAULT_OUTPUT_FILE, DEFAULT_SCHEMA_FILE, parser
+import argparse
+import os
+
 from videoipath_automation_tool.scripts.generate_driver_models import main as generate_driver_models
 from videoipath_automation_tool.scripts.generate_overloads import main as generate_overloads
+from videoipath_automation_tool.utils.script_utils import ROOT_DIR
+
+parser = argparse.ArgumentParser(description="Generate all version-specific code for a given VideoIPath version")
+parser.add_argument("version", help="Version of VideoIPath to use", default="2024.4.12", nargs="?")
 
 
-def main(
-    schema_file: str = DEFAULT_SCHEMA_FILE,
-    output_file: str = DEFAULT_OUTPUT_FILE,
-):
-    generate_driver_models(schema_file, output_file)
+def main():
+    args = parser.parse_args()
+    schema_file = os.path.join(ROOT_DIR, "apps", "inventory", "model", "driver_schema", f"{args.version}.json")
+
+    if not os.path.exists(schema_file):
+        print(
+            f"VideoIPath version {args.version} is currently not supported. Please create an issue on https://github.com/SWR-MoIP/VideoIPath-Automation-Tool/issues to request support for this version."
+        )
+        exit(1)
+
+    generate_driver_models(schema_file)
     generate_overloads()
 
 
 if __name__ == "__main__":
-    args = parser.parse_args()
-    main(args.schema_file, args.output_file)
+    main()

--- a/src/videoipath_automation_tool/scripts/generate_all.py
+++ b/src/videoipath_automation_tool/scripts/generate_all.py
@@ -1,0 +1,16 @@
+from videoipath_automation_tool.scripts.generate_driver_models import DEFAULT_OUTPUT_FILE, DEFAULT_SCHEMA_FILE, parser
+from videoipath_automation_tool.scripts.generate_driver_models import main as generate_driver_models
+from videoipath_automation_tool.scripts.generate_overloads import main as generate_overloads
+
+
+def main(
+    schema_file: str = DEFAULT_SCHEMA_FILE,
+    output_file: str = DEFAULT_OUTPUT_FILE,
+):
+    generate_driver_models(schema_file, output_file)
+    generate_overloads()
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    main(args.schema_file, args.output_file)

--- a/src/videoipath_automation_tool/scripts/generate_driver_models.py
+++ b/src/videoipath_automation_tool/scripts/generate_driver_models.py
@@ -4,7 +4,8 @@ import os
 
 from videoipath_automation_tool.utils.script_utils import ROOT_DIR, load_module
 
-DEFAULT_SCHEMA_FILE = os.path.join(ROOT_DIR, "apps", "inventory", "model", "driver_schema", "2024.3.3.json")
+DEFAULT_VERSION = "2024.4.12"
+DEFAULT_SCHEMA_FILE = os.path.join(ROOT_DIR, "apps", "inventory", "model", "driver_schema", f"{DEFAULT_VERSION}.json")
 DEFAULT_OUTPUT_FILE = os.path.join(ROOT_DIR, "apps", "inventory", "model", "drivers.py")
 
 parser = argparse.ArgumentParser(description="Generate Pydantic models from driver schema")
@@ -134,7 +135,7 @@ from pydantic import BaseModel, Field
 
 # Notes:
 # - The name of the custom settings model follows the naming convention: CustomSettings_<driver_organization>_<driver_name>_<driver_version> => "." and "-" are replaced by "_"!
-# - {schema_file} is used as reference to define the custom settings model!
+# - Schema {schema_file.split("/")[-1]} is used as reference to define the custom settings model!
 # - The "driver_id" attribute is necessary for the discriminator, which is used to determine the correct model for the custom settings in DeviceConfiguration!
 # - The "alias" attribute is used to map the attribute to the correct key (with driver organization & name) in the JSON payload for the API!
 # - "DriverLiteral" is used to provide a list of all possible drivers in the IDEs IntelliSense!

--- a/src/videoipath_automation_tool/scripts/generate_driver_models.py
+++ b/src/videoipath_automation_tool/scripts/generate_driver_models.py
@@ -1,38 +1,29 @@
 import argparse
-import importlib.util
 import json
+import os
 
+from videoipath_automation_tool.utils.script_utils import ROOT_DIR, load_module
 
-def load_pydantic_model_builder():
-    spec = importlib.util.spec_from_file_location(
-        "pydantic_model_builder", "src/videoipath_automation_tool/utils/pydantic_model_builder.py"
-    )
-
-    if spec is None or spec.loader is None:
-        raise ValueError("Failed to load pydantic_model_builder module")
-
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
+DEFAULT_SCHEMA_FILE = os.path.join(ROOT_DIR, "apps", "inventory", "model", "driver_schema", "2024.3.3.json")
+DEFAULT_OUTPUT_FILE = os.path.join(ROOT_DIR, "apps", "inventory", "model", "drivers.py")
 
 parser = argparse.ArgumentParser(description="Generate Pydantic models from driver schema")
 parser.add_argument(
     "schema_file",
     nargs="?",
-    default="src/videoipath_automation_tool/apps/inventory/model/driver_schema/2024.3.3.json",
+    default=DEFAULT_SCHEMA_FILE,
     help="Path to the driver schema JSON file",
 )
 parser.add_argument(
     "output_file",
     nargs="?",
-    default="src/videoipath_automation_tool/apps/inventory/model/drivers.py",
+    default=DEFAULT_OUTPUT_FILE,
     help="Path where the generated Python file will be saved",
 )
 
 
 def _generate_driver_model(driver_schema: dict) -> str:
-    pmb_module = load_pydantic_model_builder()
+    pmb_module = load_module("pydantic_model_builder", os.path.join(ROOT_DIR, "utils", "pydantic_model_builder.py"))
     PydanticModelBuilder = pmb_module.PydanticModelBuilder
     PydanticModelField = pmb_module.PydanticModelField
 
@@ -127,9 +118,11 @@ def _get_attribute_type(field: dict) -> tuple[str, list[tuple[str | int | float,
     return field["_schema"]["type"], None
 
 
-if __name__ == "__main__":
-    args = parser.parse_args()
-    schema = json.load(open(args.schema_file))
+def main(
+    schema_file: str = DEFAULT_SCHEMA_FILE,
+    output_file: str = DEFAULT_OUTPUT_FILE,
+):
+    schema = json.load(open(schema_file))
 
     drivers = schema["data"]["status"]["system"]["drivers"]["_items"]
     driver_models = "\n\n".join([_generate_driver_model(driver) for driver in drivers])
@@ -141,7 +134,7 @@ from pydantic import BaseModel, Field
 
 # Notes:
 # - The name of the custom settings model follows the naming convention: CustomSettings_<driver_organization>_<driver_name>_<driver_version> => "." and "-" are replaced by "_"!
-# - {args.schema_file} is used as reference to define the custom settings model!
+# - {schema_file} is used as reference to define the custom settings model!
 # - The "driver_id" attribute is necessary for the discriminator, which is used to determine the correct model for the custom settings in DeviceConfiguration!
 # - The "alias" attribute is used to map the attribute to the correct key (with driver organization & name) in the JSON payload for the API!
 # - "DriverLiteral" is used to provide a list of all possible drivers in the IDEs IntelliSense!
@@ -167,6 +160,11 @@ CustomSettingsType = TypeVar("CustomSettingsType", bound=CustomSettings)
 """
     print("Drivers generated successfully!")
 
-    with open(args.output_file, "w") as f:
+    with open(output_file, "w") as f:
         f.write(code)
-        print(f"Updated {args.output_file}")
+        print(f"Updated {output_file}")
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    main(args.schema_file, args.output_file)

--- a/src/videoipath_automation_tool/scripts/generate_overloads.py
+++ b/src/videoipath_automation_tool/scripts/generate_overloads.py
@@ -1,22 +1,14 @@
-import importlib.util
+import os
 import re
 from typing import Callable
 
+from videoipath_automation_tool.utils.script_utils import ROOT_DIR, load_module
 
-def load_driver_settings():
-    spec = importlib.util.spec_from_file_location(
-        "drivers_module", "src/videoipath_automation_tool/apps/inventory/model/drivers.py"
-    )
-
-    if spec is None or spec.loader is None:
-        raise ValueError("Failed to load drivers module")
-
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return getattr(module, "DRIVER_ID_TO_CUSTOM_SETTINGS", {})
-
-
-DRIVER_ID_TO_CUSTOM_SETTINGS = load_driver_settings()
+DRIVERS_MODULE = load_module(
+    "drivers_module",
+    os.path.join(ROOT_DIR, "apps", "inventory", "model", "drivers.py"),
+)
+DRIVER_ID_TO_CUSTOM_SETTINGS = DRIVERS_MODULE.DRIVER_ID_TO_CUSTOM_SETTINGS
 
 
 def generate_create_device_overloads() -> str:
@@ -44,7 +36,7 @@ def generate_get_device_overloads() -> str:
 
 
 def generate_overloads(method: str, generate_overloads: Callable) -> None:
-    FILE_PATH = f"src/videoipath_automation_tool/apps/inventory/app/{method}.py"
+    FILE_PATH = os.path.join(ROOT_DIR, "apps", "inventory", "app", f"{method}.py")
 
     with open(FILE_PATH, "r") as f:
         content = f.read()
@@ -70,7 +62,7 @@ def generate_overloads(method: str, generate_overloads: Callable) -> None:
     print(f"Updated overloads in {FILE_PATH} ✅")
 
 
-if __name__ == "__main__":
+def main():
     overloaded_methods = {
         "create_device": generate_create_device_overloads,
         "create_device_from_discovered_device": generate_create_device_from_discovered_device_overloads,
@@ -78,3 +70,7 @@ if __name__ == "__main__":
     }
     for method, generator in overloaded_methods.items():
         generate_overloads(method, generator)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/videoipath_automation_tool/utils/script_utils.py
+++ b/src/videoipath_automation_tool/utils/script_utils.py
@@ -1,0 +1,20 @@
+import importlib.util
+import os
+from types import ModuleType
+
+UTILS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(UTILS_DIR)
+
+
+def load_module(module_name: str, file_path: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        file_path,
+    )
+
+    if spec is None or spec.loader is None:
+        raise ValueError("Failed to load drivers module")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
Resolves #25 

Provides a script to configure the VideoIPath version for the installed library. By default, the latest version is configured - running the script is only necessary when using another version. This is how to use it:

```bash
set-videoipath-version <version> # e.g. 2024.3.3
```

The version can also be omitted to install the latest version.

### TODOs:

- [ ] Detect VideoIPath API version on connect and compare with the configured version
- [ ] Read drivers schema and compare to the configured one
- [ ] Documentation