### PR TITLE
Enhance Inventory App: Add Support to Manage and Assign Global SNMP Settings

### DIFF
--- a/src/videoipath_automation_tool/apps/inventory/app/app.py
+++ b/src/videoipath_automation_tool/apps/inventory/app/app.py
@@ -10,11 +10,13 @@ from videoipath_automation_tool.apps.inventory.app.create_device_from_discovered
 from videoipath_automation_tool.apps.inventory.app.get_device import InventoryGetDeviceMixin
 from videoipath_automation_tool.apps.inventory.inventory_api import InventoryAPI
 from videoipath_automation_tool.apps.inventory.model.drivers import CustomSettings, CustomSettingsType, DriverLiteral
+from videoipath_automation_tool.apps.inventory.model.global_snmp_config import SnmpConfiguration
 from videoipath_automation_tool.apps.inventory.model.inventory_device import InventoryDevice
 from videoipath_automation_tool.apps.inventory.model.inventory_device_configuration_compare import (
     InventoryDeviceComparison,
 )
 from videoipath_automation_tool.apps.inventory.model.inventory_discovered_device import DiscoveredInventoryDevice
+from videoipath_automation_tool.connector.models.response_rpc import ResponseRPC
 from videoipath_automation_tool.connector.vip_connector import VideoIPathConnector
 from videoipath_automation_tool.validators.device_id import validate_device_id
 
@@ -348,6 +350,83 @@ class InventoryApp(InventoryCreateDeviceMixin, InventoryCreateDeviceFromDiscover
             InventoryDevice: The created inventory device instance
         """
         return InventoryDevice.parse_configuration(config)
+
+    # --- Global SNMP Configuration Helpers ---
+    def get_global_snmp_config_id_by_label(self, label: str) -> Optional[str | List[str]]:
+        """Method to get the global SNMP configuration id by label.
+        Note: If multiple SNMP configurations with the same label exist, a list of ids is returned.
+
+        Args:
+            label (str): Label of the SNMP configuration
+
+        Returns:
+            Optional[str | List[str]]: SNMP configuration id, None if not found, List of ids if multiple configurations with the same label exist
+        """
+        return self._inventory_api.get_global_snmp_config_id_by_label(label=label)
+
+    def get_global_snmp_config_label_by_id(self, snmp_config_id: str) -> Optional[str]:
+        """Method to get the global SNMP configuration label by id.
+
+        Args:
+            snmp_config_id (str): SNMP configuration id
+
+        Returns:
+            Optional[str]: SNMP configuration label, None if not found
+        """
+        return self._inventory_api.get_global_snmp_config_label_by_id(snmp_config_id=snmp_config_id)
+
+    def get_all_global_snmp_config_ids(self) -> dict[str, str]:
+        """Method to list all global SNMP configuration ids with their labels.
+
+        Returns:
+            dict: {snmp_config_id: snmp_config_label}
+        """
+        return self._inventory_api.get_all_global_snmp_config_ids()
+
+    # --- Global SNMP Configuration CRUD Methods ---
+    def get_global_snmp_config(self, snmp_config_id: str) -> SnmpConfiguration:
+        """Method to get a global SNMP configuration by id from VideoIPath-Inventory
+
+        Args:
+            snmp_config_id (str): SNMP configuration id
+
+        Returns:
+            GlobalSnmpConfig: Global SNMP configuration object
+        """
+        return self._inventory_api.get_global_snmp_config(snmp_config_id=snmp_config_id)
+
+    def add_global_snmp_config(self, snmp_config: SnmpConfiguration) -> SnmpConfiguration:
+        """Method to add a new global SNMP configuration
+
+        Args:
+            snmp_config (SnmpConfiguration): SNMP configuration object to add
+
+        Returns:
+            SnmpConfiguration: Added SNMP configuration object
+        """
+        return self._inventory_api.add_global_snmp_config(snmp_config=snmp_config)
+
+    def update_global_snmp_config(self, snmp_config: SnmpConfiguration) -> SnmpConfiguration:
+        """Method to update a global SNMP configuration
+
+        Args:
+            snmp_config (SnmpConfiguration): SNMP configuration object to update
+
+        Returns:
+            SnmpConfiguration: Updated SNMP configuration object
+        """
+        return self._inventory_api.update_global_snmp_config(snmp_config=snmp_config)
+
+    def remove_global_snmp_config(self, snmp_config_id: str) -> ResponseRPC:
+        """Method to remove a global SNMP configuration by id from VideoIPath-Inventory
+
+        Args:
+            snmp_config_id (str): SNMP configuration id
+
+        Returns:
+            ResponseRPC: Response object
+        """
+        return self._inventory_api.remove_global_snmp_config(snmp_config_id=snmp_config_id)
 
     # --- Deprecated Methods ---
     @deprecated(

--- a/src/videoipath_automation_tool/apps/inventory/inventory_api.py
+++ b/src/videoipath_automation_tool/apps/inventory/inventory_api.py
@@ -13,6 +13,8 @@ from videoipath_automation_tool.apps.inventory.inventory_utils import (
 )
 from videoipath_automation_tool.apps.inventory.model.device_status import DeviceStatus
 from videoipath_automation_tool.apps.inventory.model.drivers import CustomSettingsType, DriverLiteral
+from videoipath_automation_tool.apps.inventory.model.global_snmp_config import SnmpConfiguration
+from videoipath_automation_tool.apps.inventory.model.global_snmp_request_rpc import SnmpRequestRpc
 from videoipath_automation_tool.apps.inventory.model.inventory_device import InventoryDevice
 from videoipath_automation_tool.apps.inventory.model.inventory_discovered_device import DiscoveredInventoryDevice
 from videoipath_automation_tool.apps.inventory.model.inventory_request_rpc import InventoryRequestRpc
@@ -664,16 +666,16 @@ class InventoryAPI:
             response.data["status"]["devman"]["discoveredDevices"]["_items"][0]
         )
 
-    # --- Global Configuration Helpers ---
-    def get_global_snmp_config_id_by_label(self, label: str) -> Optional[str]:
+    # --- Global SNMP Configuration Helpers ---
+    def get_global_snmp_config_id_by_label(self, label: str) -> Optional[str | List[str]]:
         """Method to get the global SNMP configuration id by label.
-        Note: If multiple SNMP configurations with the same label exist, the first one is returned.
+        Note: If multiple SNMP configurations with the same label exist, a list of ids is returned.
 
         Args:
             label (str): Label of the SNMP configuration
 
         Returns:
-            Optional[str]: SNMP configuration id, None if not found
+            Optional[str | List[str]]: SNMP configuration id, None if not found, List of ids if multiple configurations with the same label exist
         """
         if not label:
             raise ValueError("Label must not be empty.")
@@ -687,9 +689,9 @@ class InventoryAPI:
                 return list(matches.keys())[0]
             elif len(matches) > 1:
                 self._logger.warning(
-                    f"Multiple SNMP configurations found with label '{label}'. Returning the first one."
+                    f"Multiple SNMP configurations found with label '{label}''. Returning all matching ids."
                 )
-                return list(matches.keys())[0]
+                return list(matches.keys())
         return None
 
     def get_global_snmp_config_label_by_id(self, snmp_config_id: str) -> Optional[str]:
@@ -705,9 +707,10 @@ class InventoryAPI:
             raise ValueError("SNMP configuration id must not be empty.")
 
         url = f"/rest/v2/data/config/system/snmp/session/{snmp_config_id}/descriptor/label"
-        response = self.vip_connector.rest.get(url)
-        if response.data and response.data["config"]["system"]["snmp"]["session"][snmp_config_id]:
-            return response.data["config"]["system"]["snmp"]["session"][snmp_config_id]["descriptor"]["label"]
+        response = self.vip_connector.rest.get(url, node_check=False)
+        if response.data and response.data["config"]["system"]["snmp"]["session"]:
+            if snmp_config_id in response.data["config"]["system"]["snmp"]["session"]:
+                return response.data["config"]["system"]["snmp"]["session"][snmp_config_id]["descriptor"]["label"]
         return None
 
     def get_all_global_snmp_config_ids(self) -> dict[str, str]:
@@ -725,6 +728,106 @@ class InventoryAPI:
         return {
             snmp_config_id: snmp_config["descriptor"]["label"] for snmp_config_id, snmp_config in snmp_configs.items()
         }
+
+    # --- Global SNMP Configuration CRUD Methods ---
+    def get_global_snmp_config(self, snmp_config_id: str) -> SnmpConfiguration:
+        """Method to get a global SNMP configuration by id from VideoIPath-Inventory
+
+        Args:
+            snmp_config_id (str): SNMP configuration id
+
+        Returns:
+            GlobalSnmpConfig: Global SNMP configuration object
+        """
+        if not snmp_config_id:
+            raise ValueError("SNMP configuration id must not be empty.")
+
+        url = f"/rest/v2/data/config/system/snmp/session/{snmp_config_id}/**"
+        response = self.vip_connector.rest.get(url)
+        if not response.data:
+            raise ValueError("Response data is empty.")
+
+        return SnmpConfiguration.parse_from_dict(response.data["config"]["system"]["snmp"]["session"])
+
+    def add_global_snmp_config(self, snmp_config: SnmpConfiguration) -> SnmpConfiguration:
+        """Method to add a new global SNMP configuration
+
+        Args:
+            snmp_config (SnmpConfiguration): SNMP configuration object to add
+
+        Returns:
+            SnmpConfiguration: Added SNMP configuration object
+        """
+        if not snmp_config.id:
+            raise ValueError("SNMP configuration id must be set.")
+
+        self._logger.debug(f"Adding new global SNMP configuration with id '{snmp_config.id}'.")
+
+        existing_configs_label = self.get_global_snmp_config_label_by_id(snmp_config.id)
+        if existing_configs_label is not None:
+            raise ValueError(f"SNMP configuration with id '{snmp_config.id}' already exists. Please update it instead.")
+
+        body = SnmpRequestRpc()
+        body.add(snmp_config)
+
+        response = self.vip_connector.rpc.post("/api/updateSnmpConfig", body=body)
+
+        if response.header.status != "OK":
+            raise ValueError(f"Failed to add global SNMP configuration. Error: {response}")
+
+        return self.get_global_snmp_config(snmp_config_id=snmp_config.id)
+
+    def update_global_snmp_config(self, snmp_config: SnmpConfiguration) -> SnmpConfiguration:
+        """Method to update a global SNMP configuration
+
+        Args:
+            snmp_config (SnmpConfiguration): SNMP configuration object to update
+
+        Returns:
+            SnmpConfiguration: Updated SNMP configuration object
+        """
+        if not snmp_config.id:
+            raise ValueError("SNMP configuration id must be set.")
+
+        self._logger.debug(f"Updating global SNMP configuration with id '{snmp_config.id}'.")
+
+        existing_configs_label = self.get_global_snmp_config_label_by_id(snmp_config.id)
+        if existing_configs_label is None:
+            raise ValueError(f"SNMP configuration with id '{snmp_config.id}' does not exist. Please add it first.")
+
+        body = SnmpRequestRpc()
+        body.update(snmp_config)
+
+        response = self.vip_connector.rpc.post("/api/updateSnmpConfig", body=body)
+
+        if response.header.status != "OK":
+            raise ValueError(f"Failed to update global SNMP configuration. Error: {response}")
+
+        return self.get_global_snmp_config(snmp_config_id=snmp_config.id)
+
+    def remove_global_snmp_config(self, snmp_config_id: str) -> ResponseRPC:
+        """Method to remove a global SNMP configuration by id from VideoIPath-Inventory
+
+        Args:
+            snmp_config_id (str): SNMP configuration id
+
+        Returns:
+            ResponseRPC: Response object
+        """
+        if not snmp_config_id:
+            raise ValueError("SNMP configuration id must be set.")
+
+        self._logger.debug(f"Removing global SNMP configuration with id '{snmp_config_id}'.")
+
+        body = SnmpRequestRpc()
+        body.remove(snmp_config_id)
+
+        response = self.vip_connector.rpc.post("/api/updateSnmpConfig", body=body)
+
+        if response.header.status != "OK":
+            raise ValueError(f"Failed to remove global SNMP configuration. Error: {response}")
+
+        return response
 
     # --- Deprecated Methods ---
     @deprecated(

--- a/src/videoipath_automation_tool/apps/inventory/model/global_snmp_config.py
+++ b/src/videoipath_automation_tool/apps/inventory/model/global_snmp_config.py
@@ -1,0 +1,134 @@
+from enum import Enum
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+
+# --- User Enum Classes ---
+class SecurityLevel(int, Enum):
+    UNDEFINED = 0
+    """Undefined security level."""
+    NO_AUTH_NO_PRIV = 1
+    """NoAuthNoPriv | Without authentication and without privacy."""
+    AUTH_NO_PRIV = 2
+    """AuthNoPriv | With authentication but without privacy."""
+    AUTH_PRIV = 3
+    """AuthPriv | With authentication and with privacy."""
+
+
+class AuthProtocol(int, Enum):
+    MD5 = 2
+    """MD5 | HMAC-MD5-96 digest authentication protocol."""
+    SHA = 3
+    """SHA | HMAC-SHA-96 digest authentication protocol."""
+
+
+class PrivProtocol(int, Enum):
+    DES = 2
+    """DES | CBC-DES symmetric encryption protocol."""
+    THREE_DES = 3
+    """3DES | 3DES-EDE symmetric encryption protocol."""
+    AES128 = 4
+    """AES127 | CFB128-AES-128 privacy protocol."""
+
+
+# --- Version Enum Class ---
+class SnmpVersion(int, Enum):
+    V1 = 0
+    """SNMP version 1."""
+    V2C = 1
+    """SNMP version 2 with community security."""
+    V3 = 3
+    """SNMP version 3."""
+
+
+# --- Data Model Classes ---
+class SnmpUser(BaseModel):
+    level: SecurityLevel = SecurityLevel.NO_AUTH_NO_PRIV
+    name: str = "New User"
+    authProtocol: AuthProtocol = AuthProtocol.MD5
+    privProtocol: PrivProtocol = PrivProtocol.DES
+    engineId: str = ""
+    privPassword: str = ""
+    authPassword: str = ""
+
+
+class SnmpDescriptor(BaseModel):
+    label: str = ""
+    desc: str = ""
+
+
+class SnmpSecurityEntry(BaseModel):
+    user: str = ""  # User ID from "Users" section. Must be a valid UUID of an existing user.
+    community: str = ""  # Value from "Protocol Settings => SNMP v1/v2c Security => Write / Read community"
+
+
+class SnmpSecurity(BaseModel):
+    read: SnmpSecurityEntry = SnmpSecurityEntry(community="public")
+    write: SnmpSecurityEntry = SnmpSecurityEntry(community="private")
+
+
+class SnmpProtocolSettings(BaseModel):
+    preferredVersion: SnmpVersion = SnmpVersion.V2C
+    retries: int = 1
+    maxRepetitions: int = 10
+    useGetBulk: bool = True
+    timeout: int = 5000
+    localEngineId: str = ""
+
+
+class SnmpConfiguration(BaseModel):
+    id: str = Field(alias="_id")
+    descriptor: SnmpDescriptor = Field(default_factory=SnmpDescriptor)
+    users: dict[str, SnmpUser] = Field(default_factory=dict)
+    security: SnmpSecurity = Field(default_factory=SnmpSecurity)
+    protocol: SnmpProtocolSettings = Field(default_factory=SnmpProtocolSettings)
+
+    @classmethod
+    def create(cls):
+        """
+        Creates a new instance of SnmpConfiguration with default values.
+
+        Returns:
+            SnmpConfiguration: A new instance of SnmpConfiguration.
+        """
+        config_id = str(uuid4())
+        return cls(
+            _id=config_id,
+            descriptor=SnmpDescriptor(label="New SNMP Configuration", desc=""),
+        )
+
+    @classmethod
+    def parse_from_dict(cls, data: dict) -> "SnmpConfiguration":
+        """
+        Parses a dictionary into a SnmpConfiguration instance.
+
+        Args:
+            data (dict): The dictionary to parse.
+
+        Returns:
+            SnmpConfiguration: An instance of SnmpConfiguration.
+        """
+        if len(data.keys()) == 1:
+            config_id = list(data.keys())[0]
+            data = data[config_id]
+            data["_id"] = config_id
+        else:
+            raise ValueError("Data dictionary must contain exactly one key/value pair: <id>: <configuration>")
+        return cls(**data)
+
+    # def dump_to_dict(self) -> dict:
+    #     """
+    #     Dumps the SnmpConfiguration instance to a dictionary.
+
+    #     Returns:
+    #         dict: A dictionary representation of the SnmpConfiguration instance.
+    #     """
+    #     config_id = self.id
+    #     data = self.model_dump(mode="json", exclude={"id"})
+    #     return {config_id: data}
+
+
+# class SnmpConfig(BaseModel):
+#     id: str
+#     configuration: SnmpConfiguration = Field(default_factory=SnmpConfiguration)

--- a/src/videoipath_automation_tool/apps/inventory/model/global_snmp_request_rpc.py
+++ b/src/videoipath_automation_tool/apps/inventory/model/global_snmp_request_rpc.py
@@ -1,0 +1,51 @@
+from videoipath_automation_tool.apps.inventory.model.global_snmp_config import SnmpConfiguration
+from videoipath_automation_tool.connector.models.request_rpc import RequestRPC
+from videoipath_automation_tool.validators.uuid_4 import validate_uuid_4
+
+
+class SnmpRequestRpc(RequestRPC):
+    # Wrapper class for RequestRpc
+
+    def add(self, config: SnmpConfiguration):
+        """Method to add a new global SNMP configuration
+
+        Args:
+            config (SnmpConfiguration): SNMP configuration to add
+        """
+        try:
+            validate_uuid_4(config.id)
+        except ValueError as e:
+            raise ValueError(
+                f"To add a new global SNMP configuration, a valid 'id' (UUID 4 format) must be set in the configuration. Error: {e}"
+            )
+        return super().add(config.id, config)
+
+    def update(self, config: SnmpConfiguration):
+        """Method to update a global SNMP configuration
+
+        Args:
+            config (SnmpConfiguration): SNMP configuration to update
+        """
+        try:
+            validate_uuid_4(config.id)
+        except ValueError as e:
+            raise ValueError(
+                f"To update a global SNMP configuration, a valid 'id' (UUID 4 format) must be set in the configuration. Error: {e}"
+            )
+        return super().update(config.id, config)
+
+    def remove(self, config_id: str | list[str]):
+        """Method to remove a global SNMP configuration
+
+        Args:
+            config_id (str | list[str]): Id or List of Ids of the configuration
+        """
+        try:
+            if isinstance(config_id, list):
+                for c_id in config_id:
+                    validate_uuid_4(c_id)
+            else:
+                validate_uuid_4(config_id)
+        except ValueError as e:
+            raise ValueError(f"Invalid 'config_id' format. Must be a valid UUID 4 format. Error: {e}")
+        return super().remove(config_id)

--- a/src/videoipath_automation_tool/connector/vip_rpc_connector.py
+++ b/src/videoipath_automation_tool/connector/vip_rpc_connector.py
@@ -15,6 +15,7 @@ class VideoIPathRPCConnector(VideoIPathBaseConnector):
         "/api/uploadLicense",
         "/api/activateLicense",
         "/api/deactivateLicense",
+        "/api/updateSnmpConfig",
     }
 
     def post(self, url_path: str, body: RequestRPC, url_validation: bool = True) -> ResponseRPC:

--- a/src/videoipath_automation_tool/validators/uuid_4.py
+++ b/src/videoipath_automation_tool/validators/uuid_4.py
@@ -1,0 +1,28 @@
+import uuid
+
+
+def validate_uuid_4(uuid_4: str) -> str:
+    """
+    Validates and normalizes a UUIDv4 string.
+
+    Args:
+        uuid_4: The input string to validate.
+
+    Returns:
+        The normalized UUIDv4 string (lowercase, with dashes).
+
+    Raises:
+        ValueError: If input is not a valid UUIDv4.
+    """
+    if not isinstance(uuid_4, str):
+        raise ValueError(f"UUID must be a string, got {type(uuid_4).__name__}")
+
+    try:
+        u = uuid.UUID(uuid_4)
+    except (ValueError, AttributeError, TypeError):
+        raise ValueError(f"Invalid UUID format: '{uuid_4}'")
+
+    if u.version != 4:
+        raise ValueError(f"UUID is not version 4: '{uuid_4}'")
+
+    return str(u)

--- a/tests/validators/test_uuid_4_validator.py
+++ b/tests/validators/test_uuid_4_validator.py
@@ -1,0 +1,45 @@
+import uuid
+
+import pytest
+
+from videoipath_automation_tool.validators.uuid_4 import validate_uuid_4
+
+
+class TestValidateUUID4:
+    @pytest.mark.parametrize(
+        "uuid_str",
+        [
+            str(uuid.uuid4()),  # random, valid UUIDv4
+            "550e8400-e29b-41d4-a716-446655440000",  # valid v4-UUID
+            "00000000-0000-4000-8000-000000000000",  # minimal v4-UUID
+            "ffffffff-ffff-4fff-bfff-ffffffffffff",  # maximal v4-UUID
+            "550e8400e29b41d4a716446655440000",  # valid, no dashes
+            "550E8400-E29B-41D4-A716-446655440000",  # valid, uppercase
+        ],
+    )
+    def test_valid_uuid_4(self, uuid_str):
+        normalized = validate_uuid_4(uuid_str)
+        assert isinstance(normalized, str)
+        # Standardize to lowercase with dashes
+        assert uuid.UUID(normalized).version == 4
+
+    @pytest.mark.parametrize(
+        "uuid_str",
+        [
+            "550e8400-e29b-11d4-a716-446655440000",  # v1 instead of v4
+            "550e8400-e29b-21d4-a716-446655440000",  # v2 instead of v4
+            "550e8400-e29b-51d4-a716-446655440000",  # v5
+            "this-is-not-a-uuid",
+            "12345678-1234-1234-1234-1234567890ab",
+            "zzzzzzzz-zzzz-4zzz-8zzz-zzzzzzzzzzzz",
+            "",
+            None,
+            1234,
+            [],
+            {},
+            object(),
+        ],
+    )
+    def test_invalid_uuid_4(self, uuid_str):
+        with pytest.raises(ValueError):
+            validate_uuid_4(uuid_str)


### PR DESCRIPTION
Resolves #52 

## Summary

Adds support for managing global SNMP configurations in the Inventory App, including:

- CRUD operations for global SNMP settings  
- Label-based lookup and assignment helpers  
- Integration into the device configuration model (ID + activation flag)

This enables assigning reusable SNMP configurations to devices in a lightweight and consistent way.

## Example: Assign SNMP config to a device by label

Assuming a global SNMP configuration named **"SNMP Config for eMerge"** has already been created via the Inventory App GUI:

```python
label = "SNMP Config for eMerge"
snmp_setting_id = app.inventory.get_global_snmp_config_id_by_label(label)
device_config.set_global_snmp_setting(snmp_setting_id)
```

Optional: store the reference only (without activating it yet):

```python
device_config.set_global_snmp_setting(snmp_setting_id, activate=False)
```

To verify assigned config:

```python
device_config.get_global_snmp_setting_id()
# > ab949038-9dc4-4fc7-af4f-cba04584e686

snmp_setting_label = app.inventory.get_global_snmp_config_label_by_id("ab949038-9dc4-4fc7-af4f-cba04584e686")
print(snmp_setting_label)
# > SNMP Config for eMerge
```
