### PR TITLE
hotfix(inventory): avoid ValueError for empty device list in get_device_id_by_address

### DIFF
--- a/src/videoipath_automation_tool/apps/inventory/inventory_api.py
+++ b/src/videoipath_automation_tool/apps/inventory/inventory_api.py
@@ -555,7 +555,7 @@ class InventoryAPI:
 
         response = self.vip_connector.rest.get(url)
 
-        if response.data and response.data["config"]["devman"]["devices"]["_items"]:
+        if response.data and isinstance(response.data["config"]["devman"]["devices"]["_items"], list):
             devices = response.data["config"]["devman"]["devices"]["_items"]
         else:
             raise ValueError("Response data is empty.")


### PR DESCRIPTION
Fix: handle empty device list in get_device_id_by_address (#56)
