### PR TITLE
feat(topology): add support for nGraphResourceTransform

### DIFF
--- a/src/videoipath_automation_tool/apps/topology/model/n_graph_elements/topology_n_graph_resource_transform.py
+++ b/src/videoipath_automation_tool/apps/topology/model/n_graph_elements/topology_n_graph_resource_transform.py
@@ -1,0 +1,45 @@
+from typing import List, Literal
+
+from pydantic import Field
+
+from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_n_graph_element import (
+    Descriptor,
+    NGraphElement,
+)
+
+
+class NGraphResourceTransform(NGraphElement):
+    """
+    Represents the attributes of a nGraphResourceTransform.
+
+    """
+
+    active: bool = Field(default=True)
+    descriptor: Descriptor
+    fDescriptor: Descriptor
+    fromId: str
+    tags: List[str] = Field(default=[], description="List of tags.")
+    toId: str
+    fResourceIds: List[str] = Field(default=[], description="Factory resource ids")
+    resourceIds: List[str] = Field(default=[], description="User resource ids")
+    type: Literal["nGraphResourceTransform"] = "nGraphResourceTransform"
+
+    @property
+    def from_id(self) -> str:
+        """The source vertex ID."""
+        return self.fromId
+
+    @property
+    def to_id(self) -> str:
+        """The destination vertex ID."""
+        return self.toId
+
+    @property
+    def factory_resource_ids(self) -> List[str]:
+        """The factory resource IDs."""
+        return self.fResourceIds
+
+    @property
+    def resource_ids(self) -> List[str]:
+        """The user defined resource IDs."""
+        return self.resourceIds

--- a/src/videoipath_automation_tool/apps/topology/model/topology_device_configuration.py
+++ b/src/videoipath_automation_tool/apps/topology/model/topology_device_configuration.py
@@ -17,6 +17,9 @@ from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_n_
     MapsElement,
     SdpStrategy,
 )
+from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_n_graph_resource_transform import (
+    NGraphResourceTransform,
+)
 from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_unidirectional_edge import (
     UnidirectionalEdge,
 )
@@ -34,6 +37,7 @@ class TopologyDeviceConfiguration(BaseModel):
         codec_vertices (List[CodecVertex]): Configuration of the codec vertices of the device
         internal_edges (List[UnidirectionalEdge]): Configuration of the internal unidirectional edges of the device (All edges that connect vertices within the same device)
         external_edges (List[UnidirectionalEdge]): Configuration of the external unidirectional edges of the device (All edges that connect this device to other devices)
+        resource_transform_edges (List[NGraphResourceTransform]): Configuration of the resource transform edges of the device
     """
 
     base_device: BaseDevice
@@ -42,6 +46,7 @@ class TopologyDeviceConfiguration(BaseModel):
     codec_vertices: List[CodecVertex] = Field(default_factory=list)
     internal_edges: List[UnidirectionalEdge] = Field(default_factory=list)
     external_edges: List[UnidirectionalEdge] = Field(default_factory=list)
+    resource_transform_edges: List[NGraphResourceTransform] = Field(default_factory=list)
 
     # --- Setters and Getters ---
 
@@ -245,7 +250,7 @@ class TopologyDeviceConfiguration(BaseModel):
 
     def get_nGraphElement_by_id(
         self, element_id: str
-    ) -> Optional[BaseDevice | GenericVertex | IpVertex | CodecVertex | UnidirectionalEdge]:
+    ) -> Optional[BaseDevice | GenericVertex | IpVertex | CodecVertex | UnidirectionalEdge | NGraphResourceTransform]:
         """Get an nGraphElement by its ID. Method will return the first element found with the specified ID.
 
         Args:
@@ -261,6 +266,7 @@ class TopologyDeviceConfiguration(BaseModel):
             self.codec_vertices,
             self.internal_edges,
             self.external_edges,
+            self.resource_transform_edges,
         )
 
         matching_element = next((element for element in all_elements if element.id == element_id), None)

--- a/src/videoipath_automation_tool/apps/topology/model/topology_device_configuration_compare.py
+++ b/src/videoipath_automation_tool/apps/topology/model/topology_device_configuration_compare.py
@@ -7,6 +7,9 @@ from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_co
 from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_generic_vertex import GenericVertex
 from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_ip_vertex import IpVertex
 from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_n_graph_element import NGraphElement
+from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_n_graph_resource_transform import (
+    NGraphResourceTransform,
+)
 from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_unidirectional_edge import (
     UnidirectionalEdge,
 )
@@ -249,6 +252,7 @@ class TopologyDeviceComparison(BaseModel):
     codec_vertices: NGraphElementListComparison
     internal_edges: NGraphElementListComparison
     external_edges: NGraphElementListComparison
+    resource_transform_edges: NGraphElementListComparison
 
     @classmethod
     def analyze_topology_devices(
@@ -273,6 +277,10 @@ class TopologyDeviceComparison(BaseModel):
         external_edges = cls.create_compare_list(
             reference_device.configuration.external_edges, staged_device.configuration.external_edges
         )
+        resource_transform_edges = cls.create_compare_list(
+            reference_device.configuration.resource_transform_edges,
+            staged_device.configuration.resource_transform_edges,
+        )
 
         return cls(
             reference_device=reference_device,
@@ -283,6 +291,7 @@ class TopologyDeviceComparison(BaseModel):
             codec_vertices=codec_vertices,
             internal_edges=internal_edges,
             external_edges=external_edges,
+            resource_transform_edges=resource_transform_edges,
         )
 
     @staticmethod
@@ -291,12 +300,14 @@ class TopologyDeviceComparison(BaseModel):
         | List[GenericVertex]
         | List[IpVertex]
         | List[CodecVertex]
-        | List[UnidirectionalEdge],
+        | List[UnidirectionalEdge]
+        | List[NGraphResourceTransform],
         staged_elements: List[NGraphElement]
         | List[GenericVertex]
         | List[IpVertex]
         | List[CodecVertex]
-        | List[UnidirectionalEdge],
+        | List[UnidirectionalEdge]
+        | List[NGraphResourceTransform],
     ) -> NGraphElementListComparison:
         """Method to create a comparison list between two lists of nGraphElements."""
         reference_element_ids = [element.id for element in reference_elements]
@@ -353,6 +364,9 @@ class TopologyDeviceComparison(BaseModel):
         if len(self.external_edges.get_changed(include_rev)) > 0:
             changed_elements += self.external_edges.get_changed(include_rev)
 
+        if len(self.resource_transform_edges.get_changed(include_rev)) > 0:
+            changed_elements += self.resource_transform_edges.get_changed(include_rev)
+
         return changed_elements
 
     def get_added_elements(self) -> List[NGraphElement]:
@@ -363,6 +377,7 @@ class TopologyDeviceComparison(BaseModel):
         added_elements += self.codec_vertices.get_added()
         added_elements += self.internal_edges.get_added()
         added_elements += self.external_edges.get_added()
+        added_elements += self.resource_transform_edges.get_added()
         return added_elements
 
     def get_removed_elements(self) -> List[NGraphElement]:
@@ -373,4 +388,5 @@ class TopologyDeviceComparison(BaseModel):
         removed_elements += self.codec_vertices.get_removed()
         removed_elements += self.internal_edges.get_removed()
         removed_elements += self.external_edges.get_removed()
+        removed_elements += self.resource_transform_edges.get_removed()
         return removed_elements

--- a/src/videoipath_automation_tool/apps/topology/topology_app.py
+++ b/src/videoipath_automation_tool/apps/topology/topology_app.py
@@ -8,6 +8,9 @@ from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_ba
 from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_codec_vertex import CodecVertex
 from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_generic_vertex import GenericVertex
 from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_ip_vertex import IpVertex
+from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_n_graph_resource_transform import (
+    NGraphResourceTransform,
+)
 from videoipath_automation_tool.apps.topology.model.n_graph_elements.topology_unidirectional_edge import (
     UnidirectionalEdge,
 )
@@ -165,7 +168,7 @@ class TopologyApp:
 
     def get_element_by_id(
         self, vertex_id: str
-    ) -> BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex:
+    ) -> BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex | NGraphResourceTransform:
         """
         Get an element by its unique id.
 
@@ -173,7 +176,7 @@ class TopologyApp:
             vertex_id (str): Unique Vertex id.
 
         Returns:
-            BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex: nGraph element object.
+            BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex | NGraphResourceTransform: nGraph element object.
         """
         return self._topology_api._fetch_nGraphElement_by_key(vertex_id)
 
@@ -182,7 +185,13 @@ class TopologyApp:
         vertex_label: str,
         mode: Literal["user_defined", "factory"] = "user_defined",
         filter_type: Literal[
-            "all", "base_device", "codec_vertex", "ip_vertex", "unidirectional_edge", "generic_vertex"
+            "all",
+            "base_device",
+            "codec_vertex",
+            "ip_vertex",
+            "unidirectional_edge",
+            "generic_vertex",
+            "n_graph_resource_transform",
         ] = "all",
     ) -> (
         BaseDevice
@@ -190,7 +199,8 @@ class TopologyApp:
         | IpVertex
         | UnidirectionalEdge
         | GenericVertex
-        | List[BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex]
+        | NGraphResourceTransform
+        | List[BaseDevice | CodecVertex | GenericVertex | IpVertex | UnidirectionalEdge | NGraphResourceTransform]
     ):
         """Get an element by its label.
 
@@ -204,12 +214,15 @@ class TopologyApp:
         """
         return self._topology_api.get_element_by_label(vertex_label, mode, filter_type)
 
-    def update_element(self, element: BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex):
+    def update_element(
+        self,
+        element: BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex | NGraphResourceTransform,
+    ):
         """
         Update a single nGraph element in the topology.
 
         Args:
-            vertex (BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex): nGraph element object.
+            vertex (BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex | NGraphResourceTransform): nGraph element object.
         """
         return self._topology_api.update_element(element)
 
@@ -334,7 +347,8 @@ class TopologyApp:
         | IpVertex
         | UnidirectionalEdge
         | GenericVertex
-        | List[BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex]
+        | NGraphResourceTransform
+        | List[BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex | NGraphResourceTransform]
     ):
         self._logger.warning(
             "Method 'get_vertex_by_label' is deprecated. It will be removed in future versions. Please use 'get_element_by_label' instead."
@@ -342,12 +356,14 @@ class TopologyApp:
         return self._topology_api.get_element_by_label(vertex_label, mode)
 
     @deprecated("This method is deprecated and will be removed in future versions. Use 'update_element' instead.")
-    def update_vertex(self, vertex: BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex):
+    def update_vertex(
+        self, vertex: BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex | NGraphResourceTransform
+    ):
         """
         Update a single vertex in the topology.
 
         Args:
-            vertex (BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex): Vertex object.
+            vertex (BaseDevice | CodecVertex | IpVertex | UnidirectionalEdge | GenericVertex | NGraphResourceTransform): Vertex object.
         """
         self._logger.warning(
             "Method 'update_vertex' is deprecated. It will be removed in future versions. Please use 'update_element' instead."


### PR DESCRIPTION
### Resolves #61

**Summary of Changes:**

- Added `NGraphResourceTransform` model to represent resource transformation elements.
- Updated the `TopologyDeviceConfiguration` model to include `resource_transform_edges` as an additional field, containing the list of resource transformation elements associated with the device. This allows these elements to be handled and compared in the same way as other vertices and edges.
- Enhanced the comparison model for device configurations (`TopologyDeviceConfigurationCompare`) to also support the new `resource_transform_edges` list.
- Refined API and APP methods in the `TopologyAPI` and `TopologyAPP` to handle`NGraphResourceTransform` elements across relevant functions.