### PR TITLE
Add property to get module number in vertices

### DIFF
--- a/src/videoipath_automation_tool/apps/topology/model/n_graph_elements/topology_vertex.py
+++ b/src/videoipath_automation_tool/apps/topology/model/n_graph_elements/topology_vertex.py
@@ -120,6 +120,10 @@ class Vertex(NGraphElement, validate_assignment=True):
         return self.deviceId
 
     @property
+    def module_number(self) -> int:
+        return int(self.id.split(".")[2])
+
+    @property
     def is_virtual(self) -> bool:
         """Indicates if the vertex is virtual"""
         return self.isVirtual

--- a/src/videoipath_automation_tool/apps/topology/model/n_graph_elements/topology_vertex.py
+++ b/src/videoipath_automation_tool/apps/topology/model/n_graph_elements/topology_vertex.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 
 from pydantic import Field, field_validator
 
@@ -120,9 +120,12 @@ class Vertex(NGraphElement, validate_assignment=True):
         return self.deviceId
 
     @property
-    def module_number(self) -> int:
-        """Module number that this vertex is part of"""
-        return int(self.id.split(".")[2])
+    def module_id(self) -> Optional[str]:
+        """Module identifier this vertex belongs to, or None for common vertices (e.g. SwitchingCore)."""
+        pid = self.gpid.pointId
+        if len(pid) >= 4 and pid[1] in ("dev", "virt"):
+            return pid[2]
+        return None
 
     @property
     def is_virtual(self) -> bool:

--- a/src/videoipath_automation_tool/apps/topology/model/n_graph_elements/topology_vertex.py
+++ b/src/videoipath_automation_tool/apps/topology/model/n_graph_elements/topology_vertex.py
@@ -121,6 +121,7 @@ class Vertex(NGraphElement, validate_assignment=True):
 
     @property
     def module_number(self) -> int:
+        """Module number that this vertex is part of"""
         return int(self.id.split(".")[2])
 
     @property


### PR DESCRIPTION
I've added a property to get the module number of a vertex, simply by splitting the id - a very simple addition.

I need to be able to get the module number of a vertex as I have a need to duplicate a virtual device. While I could have the required code at my end, I wonder if it would be useful to be part of the Vertex class.