### PR TITLE
Fix for Use of exit() or quit()

### DIFF
--- a/src/vipat_cli_scripts/generate_all.py
+++ b/src/vipat_cli_scripts/generate_all.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from pathlib import Path
 
 from vipat_cli_scripts.generate_driver_models import main as generate_driver_models
@@ -20,7 +21,7 @@ def main():
         versions = list_available_schema_versions()
         for version in versions:
             print(f"- {version}")
-        exit(1)
+        sys.exit(1)
 
     generate_driver_models(schema_file)
 


### PR DESCRIPTION
Use `sys.exit(1)` instead of `exit(1)`.

Best fix (without changing functionality):
- In `src/vipat_cli_scripts/generate_all.py`, add `import sys` with the existing imports.
- Replace `exit(1)` at line 23 with `sys.exit(1)`.

This preserves behavior (exit status code 1 on unsupported version) while removing dependence on `site.Quitter`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._