### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/src/videoipath_automation_tool/apps/inventory/model/inventory_device_configuration_compare.py
+++ b/src/videoipath_automation_tool/apps/inventory/model/inventory_device_configuration_compare.py
@@ -83,7 +83,7 @@ class InventoryDeviceComparison(BaseModel):
         path = path.removeprefix("root")
 
         # Convert the string path into a list of keys
-        path_parts = path_parts = path.replace("']['", "/")[2:-2].split("/")
+        path_parts = path.replace("']['", "/")[2:-2].split("/")
 
         # extract the value
         for part in path_parts:


### PR DESCRIPTION
The fix is to remove the redundant self-assignment and keep a single assignment to `path_parts` in `get_value_by_path`.

Best fix without changing behavior:
- File: `src/videoipath_automation_tool/apps/inventory/model/inventory_device_configuration_compare.py`
- Region: `get_value_by_path` method, line 86 in the provided snippet.
- Change:
  - From: `path_parts = path_parts = path.replace("']['", "/")[2:-2].split("/")`
  - To: `path_parts = path.replace("']['", "/")[2:-2].split("/")`

No imports, new methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._