### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/src/videoipath_automation_tool/apps/topology/model/topology_device_configuration_compare.py
+++ b/src/videoipath_automation_tool/apps/topology/model/topology_device_configuration_compare.py
@@ -67,7 +67,7 @@ class NGraphElementDiff(BaseModel):
         path = path.removeprefix("root")
 
         # Convert the string path into a list of keys
-        path_parts = path_parts = path.replace("']['", "/")[2:-2].split("/")
+        path_parts = path.replace("']['", "/")[2:-2].split("/")
 
         # extract the value
         for part in path_parts:


### PR DESCRIPTION
The fix is to remove the duplicated self-assignment and keep a single assignment to `path_parts`.

Best minimal fix (no functionality change):
- In `src/videoipath_automation_tool/apps/topology/model/topology_device_configuration_compare.py`, method `get_value_by_path`, replace line 70:
  - from `path_parts = path_parts = path.replace("']['", "/")[2:-2].split("/")`
  - to `path_parts = path.replace("']['", "/")[2:-2].split("/")`

No imports, helper methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._