### PR TITLE
Fix for Implicit string concatenation in a list

### DIFF
--- a/src/videoipath_automation_tool/apps/inventory/model/inventory_device_configuration_compare.py
+++ b/src/videoipath_automation_tool/apps/inventory/model/inventory_device_configuration_compare.py
@@ -109,7 +109,7 @@ class InventoryDeviceComparison(BaseModel):
                 "type_changes",  # Indicates changes in the data type of an object
                 "iterable_item_added",  # Identifies items added to an iterable (e.g., lists, tuples)
                 "iterable_item_removed",  # Identifies items removed from an iterable (e.g., lists, tuples)
-                "unprocessed"  # Indicates differences that were not processed by DeepDiff
+                "unprocessed",  # Indicates differences that were not processed by DeepDiff
                 "dictionary_item_added",  # Identifies items added to a dictionary
                 "dictionary_item_removed",  # Identifies items removed from a dictionary
             ]


### PR DESCRIPTION
The fix is to add the missing comma after `"unprocessed"` so it remains a separate element and does not concatenate with `"dictionary_item_added"`.

Best minimal fix (no functional changes beyond correcting the bug):
- File: `src/videoipath_automation_tool/apps/inventory/model/inventory_device_configuration_compare.py`
- Region: `allowed_diff_types` list in `analyze_inventory_devices`
- Change:
  - From: `"unprocessed"  # ...`
  - To: `"unprocessed",  # ...`

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._