### PR TITLE
Fix for Implicit string concatenation in a list

### DIFF
--- a/src/videoipath_automation_tool/apps/topology/model/topology_device_configuration_compare.py
+++ b/src/videoipath_automation_tool/apps/topology/model/topology_device_configuration_compare.py
@@ -94,7 +94,7 @@ class NGraphElementDiff(BaseModel):
                 "type_changes",  # Indicates changes in the data type of an object
                 "iterable_item_added",  # Identifies items added to an iterable (e.g., lists, tuples)
                 "iterable_item_removed",  # Identifies items removed from an iterable (e.g., lists, tuples)
-                "unprocessed"  # Indicates differences that were not processed by DeepDiff
+                "unprocessed",  # Indicates differences that were not processed by DeepDiff
                 "dictionary_item_added",  # Identifies items added to a dictionary
                 "dictionary_item_removed",  # Identifies items removed from a dictionary
             ]


### PR DESCRIPTION
The correct fix is to add the missing comma after `"unprocessed"` in `allowed_diff_types` so each allowed DeepDiff type remains a distinct list item.

Best single fix (no functional redesign, minimal change):
- File: `src/videoipath_automation_tool/apps/topology/model/topology_device_configuration_compare.py`
- Region: `allowed_diff_types` definition inside `compare_nGraphElement`
- Change line with `"unprocessed"` to include a trailing comma.

No new methods/imports/definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._